### PR TITLE
promoteId can be string or object

### DIFF
--- a/src/components/sources/geojson.source.ts
+++ b/src/components/sources/geojson.source.ts
@@ -40,7 +40,7 @@ export default defineComponent({
 		clusterProperties: Object as PropType<object>,
 		lineMetrics: Boolean as PropType<boolean>,
 		generateId: Boolean as PropType<boolean>,
-		promoteId: Object as PropType<PromoteIdSpecification>,
+		promoteId: [Object, String] as PropType<PromoteIdSpecification>,
 		filter: [Array, String, Object] as PropType<any>,
 	},
 	setup(props) {

--- a/src/components/sources/vector.source.ts
+++ b/src/components/sources/vector.source.ts
@@ -20,7 +20,7 @@ export default defineComponent({
 		minzoom: Number as PropType<number>,
 		maxzoom: Number as PropType<number>,
 		attribution: String as PropType<string>,
-		promoteId: Object as PropType<PromoteIdSpecification>,
+		promoteId: [Object, String] as PropType<PromoteIdSpecification>,
 	},
 	setup(props) {
 		const map = inject(mapSymbol)!,


### PR DESCRIPTION
I'll link to the PR in the grandparent repository for further explication: https://github.com/razorness/vue-maplibre-gl/pull/54.

Generally, I'd appreciate if we could consolidate the code bases. For that, we should hear from @razorness and possibly @rotu and @mskr about the state of their involvement.

A possible solution could be to move to an organization account. From there, all could work on this at their own speed and capacity while maintaining one source of truth. The vision on the scope and direction of the project should already be relatively well aligned between contributors as to its bridging nature between Vue and MapLibre. The ToDos we have can serve as a valuable starting point. 

What are your opinions on this?
